### PR TITLE
Make module name upper-case in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Require it as a Node module
 ------------------------------
 
 ``` js
-var output = require('r2').swap(css)
+var output = require('R2').swap(css)
 ```
 
 Test It


### PR DESCRIPTION
The module name `R2` was lower case in README example which was not working on case-sensitive file systems (Linux, MacOS etc.). This patch fixes the example.
