### PR TITLE
Switch to an AST based parser and builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "R2",
   "description": "a CSS LTR ∞ RTL converter",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "homepage": "https://github.com/ded/r2",
   "author": "Dustin Diaz <dustin@dustindiaz.com>",
   "maintainers": ["Burak Yigit Kaya <me@byk.im>"],
@@ -19,6 +19,10 @@
   },
   "directories": {
     "bin": "bin"
+  },
+  "dependencies": {
+    "css-parse": "~1.6.0",
+    "css-stringify": "~1.4.0"
   },
   "devDependencies": {
     "sink-test": ">= 1.0.1"

--- a/r2.js
+++ b/r2.js
@@ -122,8 +122,10 @@ function processRule(rule) {
 }
 
 function processDeclaration(declaration) {
-  var prop = declaration.property
-    , val = declaration.value
+  // RegEx for comments is taken from http://www.w3.org/TR/CSS21/grammar.html
+  var commentRegEx = /\/\*[^*]*\*+([^/*][^*]*\*+)*\//g
+    , prop = declaration.property.replace(commentRegEx, '') // remove comments
+    , val = declaration.value.replace(commentRegEx, '')
     , important = /!important/
     , isImportant = val.match(important)
     , asterisk = prop.match(/^(\*+)(.+)/, '')

--- a/r2.js
+++ b/r2.js
@@ -122,6 +122,10 @@ function processRule(rule) {
 }
 
 function processDeclaration(declaration) {
+  // Ignore comments in declarations
+  if (declaration.type !== 'declaration')
+    return
+
   // RegEx for comments is taken from http://www.w3.org/TR/CSS21/grammar.html
   var commentRegEx = /\/\*[^*]*\*+([^/*][^*]*\*+)*\//g
     , prop = declaration.property.replace(commentRegEx, '') // remove comments

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -199,7 +199,7 @@ sink('media expressions', function (test, ok, b, a, assert) {
   test('should handle media declarations', function (done) {
     assert.equal(
         swap('@media (max-width: 320px) { #myid { margin-right: 1px; } .cls { padding-left: 3px; } } td { float: left; }'),
-        '@media (max-width:320px){#myid{margin-left:1px;}.cls{padding-right:3px;}}td{float:right;}',
+        '@media (max-width: 320px){#myid{margin-left:1px;}.cls{padding-right:3px;}}td{float:right;}',
         'Handled media expression properly')
     done()
   })
@@ -209,6 +209,13 @@ sink('asterisk', function (test, ok, before, after, assert) {
   test('should not ignore rules starting with asterisk', function (done) {
     assert.equal(swap('p{*left:50%;}'), 'p{*right:50%;}', '*left: 50% => *right: 50%')
     assert.equal(swap('p{*text-align:right;}'), 'p{*text-align:left;}', '*text-align: right => *text-align: left')
+    done()
+  })
+})
+
+sink('semicolon in content', function (test, ok, before, after, assert) {
+  test('should not fail when there is a quoted semicolon in the declaration', function (done) {
+    assert.equal(swap('b.broke:before { content:"&darr;";}'), 'b.broke:before{content:"&darr;";}', 'Semicolon didn\'t affect parsing')
     done()
   })
 })

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -220,4 +220,17 @@ sink('semicolon in content', function (test, ok, before, after, assert) {
   })
 })
 
+sink('comments in property names or values', function (test, ok, before, after, assert) {
+  test('should ignore comments in property names and values', function (done) {
+    assert.equal(swap('hello { padding/*hello*/: 1px 2px;}'), 'hello{padding:1px 2px;}', 'Ignored comment in property name')
+    assert.equal(swap('hello { padding: 1px/* some comment*/ 2px/*another*/;}'), 'hello{padding:1px 2px;}', 'Ignored comments in value')
+    assert.equal(swap(
+        'hello { padding/*I*//*comment*/: 1px/* every*/ /*single*/2px/*space*/;}')
+      , 'hello{padding:1px 2px;}'
+      , 'Ignored comments in both property name and value'
+    )
+    done()
+  })
+})
+
 start()

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -233,4 +233,12 @@ sink('comments in property names or values', function (test, ok, before, after, 
   })
 })
 
+sink('comments', function (test, ok, before, after, assert) {
+  test('should ignore comments', function (done) {
+    assert.equal(swap('/*le comment*/ p { margin-left: 5px;}'), 'p{margin-right:5px;}', 'Ignored comment before rule')
+    assert.equal(swap('p { /*le comment*/\nmargin-left: 5px;}'), 'p{margin-right:5px;}', 'Ignored comment before declaration')
+    done()
+  })
+})
+
 start()


### PR DESCRIPTION
Starts using [visionmedia/css-parse](https://github.com/visionmedia/css-parse) and [visionmedia/css-stringify](https://github.com/visionmedia/css-stringify) for
parsing the source and building the results. This avoids the messy and
hard to modify RegExes used to parse the source and makes it easier to
address issues like #19 or #18, adds the ability to add source maps and
fixes #8.
